### PR TITLE
Add price and fix reservation modal

### DIFF
--- a/app/Http/Controllers/Api/Shop/ReservationController.php
+++ b/app/Http/Controllers/Api/Shop/ReservationController.php
@@ -55,6 +55,7 @@ class ReservationController extends Controller
             'start_time' => 'required|date_format:H:i',
             'end_time' => 'required|date_format:H:i|after:start_time',
             'duration_minutes' => 'nullable|integer|min:1',
+            'price' => 'nullable|integer',
         ]);
 
         $reservation->update($validated);

--- a/app/Http/Requests/StoreReservationWithCustomerRequest.php
+++ b/app/Http/Requests/StoreReservationWithCustomerRequest.php
@@ -31,6 +31,7 @@ class StoreReservationWithCustomerRequest extends FormRequest
             'reservation_source_id' => 'nullable|exists:reservation_sources,id',
             'customer_name' => 'required|string|max:255',
             'customer_phone' => 'nullable|string|max:20',
+            'price' => 'nullable|integer',
         ];
     }
 
@@ -59,6 +60,7 @@ class StoreReservationWithCustomerRequest extends FormRequest
             'customer_name.required' => '顧客名を入力してください。',
             'customer_name.string' => '顧客名は文字列で入力してください。',
             'customer_phone.string' => '電話番号は文字列で入力してください。',
+            'price.integer' => '金額は数値で入力してください。',
         ];
     }
 }

--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -18,6 +18,7 @@ class Reservation extends Model
         'start_time',
         'end_time',
         'duration_minutes',
+        'price',
         'memo',
     ];
 

--- a/app/Usecases/Reservation/StoreReservationUsecase.php
+++ b/app/Usecases/Reservation/StoreReservationUsecase.php
@@ -33,6 +33,7 @@ class StoreReservationUseCase
             'memo' => 'nullable|string',
             'shop_id' => 'required|exists:shops,id',
             'reservation_source_id' => 'nullable|exists:reservation_sources,id',
+            'price' => 'nullable|integer',
         ], [
             'reserved_date.required' => '予約日を入力してください。',
             'reserved_date.date' => '予約日には正しい日付を入力してください。',
@@ -50,6 +51,7 @@ class StoreReservationUseCase
             'shop_id.required' => '店舗IDが必要です（システムエラー）。',
             'shop_id.exists' => '店舗が存在しません（システムエラー）。',
             'reservation_source_id.exists' => '予約元媒体の情報が正しくありません。',
+            'price.integer' => '金額は数値で入力してください。',
         ]);
 
         if ($validator->fails()) {

--- a/app/Usecases/Reservation/StoreReservationWithCustomerUsecase.php
+++ b/app/Usecases/Reservation/StoreReservationWithCustomerUsecase.php
@@ -62,6 +62,7 @@ class StoreReservationWithCustomerUseCase
                 'end_time'      => $data['end_time'],
                 'memo' => $data['memo'] ?? null,
                 'reservation_source_id' => $data['reservation_source_id'] ?? null,
+                'price' => $data['price'] ?? null,
             ]);
         });
     }

--- a/database/factories/ReservationFactory.php
+++ b/database/factories/ReservationFactory.php
@@ -47,6 +47,7 @@ class ReservationFactory extends Factory
             'reserved_date' => $start->format('Y-m-d'),
             'start_time' => $start->format('H:i'),
             'end_time' => $end->format('H:i'),
+            'price' => $this->faker->numberBetween(1000, 10000),
             'memo' => $this->faker->realText(20),
         ];
     }

--- a/resources/js/pages/shop/Reservation/EditReservationModal.vue
+++ b/resources/js/pages/shop/Reservation/EditReservationModal.vue
@@ -8,8 +8,10 @@
                 {{ reservation.id ? "予約の編集" : "新規予約" }}
             </h2>
 
+            <div class="grid grid-cols-2 gap-4">
+
             <!-- お名前 -->
-            <div class="mb-4">
+            <div class="mb-4 col-span-2">
                 <label class="block text-sm font-medium mb-1">お名前</label>
                 <Multiselect
                     v-model="form.customer"
@@ -48,7 +50,7 @@
             </div>
 
             <!-- 新規顧客名入力欄（customer_id が 0 のときのみ表示） -->
-            <div v-if="form.customer_id == 0" class="mb-4">
+            <div v-if="form.customer_id == 0" class="mb-4 col-span-2">
                 <label class="block text-sm font-semibold text-gray-700 mb-1"
                     >お名前</label
                 >
@@ -61,7 +63,7 @@
             </div>
 
             <!-- メニュー -->
-            <div class="mb-4">
+            <div class="mb-4 col-span-2">
                 <label class="block text-sm font-semibold text-gray-700 mb-1"
                     >メニュー</label
                 >
@@ -78,6 +80,15 @@
                         {{ menu.name }}
                     </option>
                 </select>
+            </div>
+
+            <div class="mb-4">
+                <label class="block text-sm font-semibold text-gray-700 mb-1">金額</label>
+                <input
+                    type="number"
+                    v-model.number="form.price"
+                    class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                />
             </div>
 
             <!-- 開始時間 -->
@@ -156,6 +167,7 @@
                     placeholder="メモ（任意）"
                 />
             </div>
+            </div>
             <!-- ボタン -->
             <div class="mt-6 flex justify-end gap-3">
                 <button
@@ -198,6 +210,7 @@ const form = ref({
     menu_id: null,
     start_time: "",
     end_time: "",
+    price: null,
     reservation_status: "confirmed", // ← 追加
     reservation_source_id: "",
     memo: "",
@@ -277,8 +290,9 @@ watch(
                 : null;
             form.value.customer_name = res.customer?.name || "";
             form.value.menu_id = res.menu?.id ?? null;
-            form.value.start_time = res.start_time;
-            form.value.end_time = res.end_time;
+            form.value.start_time = formatTime(res.start_time);
+            form.value.end_time = formatTime(res.end_time);
+            form.value.price = res.price;
             // 追加分
             form.value.reservation_status =
                 res.reservation_status || "confirmed";
@@ -339,6 +353,7 @@ const save = async () => {
         const payload = {
             customer_id: customerId,
             menu_id: form.value.menu_id,
+            price: form.value.price,
             start_time: form.value.start_time,
             end_time: form.value.end_time,
             reserved_date: props.reservation.reserved_date,


### PR DESCRIPTION
## Summary
- add `price` column to Reservation model and update backend validation
- include price in reservation factory
- show price input and style reservation modal in two columns
- format start time values correctly in modal

## Testing
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_688b850b1e1c8329987cf962256dd248