### PR TITLE
Add month calendar view

### DIFF
--- a/resources/js/pages/shop/Reservation/EditReservationModal.vue
+++ b/resources/js/pages/shop/Reservation/EditReservationModal.vue
@@ -190,7 +190,7 @@
 <script setup>
 import { ref, watch, onMounted, computed } from "vue";
 import axios from "axios";
-import CustomerCreateModal from "../customer/CustomerCreateModal.vue";
+import CustomerCreateModal from "../Customer/CustomerCreateModal.vue";
 import { useShopStore } from "@/stores/shop";
 const shopStore = useShopStore();
 const shop = computed(() => shopStore.shop);

--- a/resources/js/router/index.js
+++ b/resources/js/router/index.js
@@ -2,15 +2,15 @@ import { createRouter, createWebHistory } from "vue-router";
 import { h } from 'vue';
 
 // 機能ごとのページを分かりやすくインポート
-import ReservationPage from "../pages/shop/reservation/ReservationPage.vue";
-import CalendarView from "../pages/shop/reservation/CalendarView.vue";
+import ReservationPage from "../pages/shop/Reservation/ReservationPage.vue";
+import CalendarView from "../pages/shop/Reservation/CalendarView.vue";
 import SettingsLayout from "../pages/shop/settings/SettingsLayout.vue";
 import StaffList from "../pages/shop/settings/staff/StaffList.vue";
 import ShopForm from "../pages/shop/settings/shop/ShopForm.vue";
 import MenuList from "../pages/shop/settings/menu/MenuList.vue";
 import MenuCreate from "../pages/shop/settings/menu/MenuCreate.vue";
 import MenuEdit from "../pages/shop/settings/menu/MenuEdit.vue";
-import CustomerList from "../pages/shop/customer/CustomerList.vue";
+import CustomerList from "../pages/shop/Customer/CustomerList.vue";
 import SalesList from "../pages/shop/sales/SalesList.vue";
 import UserList from "../pages/customer/UserList.vue";
 import CustomerLogin from "../pages/customer/Login.vue";
@@ -20,7 +20,7 @@ import ReservationSourceCreate from "../pages/shop/settings/reservation_source/R
 import ReservationSourceEdit from "../pages/shop/settings/reservation_source/ReservationSourceEdit.vue";
 import ReservationSourceList from "../pages/shop/settings/reservation_source/ReservationSourceList.vue";
 
-import Login from "../pages/shop/auth/Login.vue";
+import Login from "../pages/shop/Auth/Login.vue";
 import { useShopAuth } from "../composables/useShopAuth";
 import { useShopStore } from "@/stores/shop";
 import StaffLogin from "../pages/staff/Login.vue";
@@ -57,13 +57,13 @@ const routes = [
     {
         path: "/shop/customers/create",
         name: "shop.customer.create",
-        component: () => import("../pages/shop/customer/CustomerCreate.vue"),
+        component: () => import("../pages/shop/Customer/CustomerCreate.vue"),
         meta: { requiresAuth: true },
     },
     {
         path: "/shop/customers/:id/edit",
         name: "shop.customer.edit",
-        component: () => import("../pages/shop/customer/CustomerEdit.vue"),
+        component: () => import("../pages/shop/Customer/CustomerEdit.vue"),
         meta: { requiresAuth: true },
     },
     // ✅ 設定系をグループ化


### PR DESCRIPTION
## Summary
- implement navigation and event emits for month calendar
- show reservations per day with overflow indication
- highlight selected date with custom colors
- fix import paths and integrate month view to router

## Testing
- `composer test` *(fails: autoload file missing)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d4830c97883298fd71d21d6e851e3