### PR TITLE
Improve month calendar loading

### DIFF
--- a/resources/js/pages/shop/Reservation/ReservationPage.vue
+++ b/resources/js/pages/shop/Reservation/ReservationPage.vue
@@ -76,9 +76,16 @@ const openNewModal = (info) => {
 const reloadReservations = async () => {
     if (!shop.value) return;
     try {
+        const start = dayjs(currentDate.value)
+            .startOf("month")
+            .format("YYYY-MM-DD");
+        const end = dayjs(currentDate.value)
+            .endOf("month")
+            .format("YYYY-MM-DD");
         const res = await axios.get("/api/shop/reservations", {
             params: {
-                date: currentDate.value, // ← 今日の日付などに変更してもOK
+                from: start,
+                to: end,
             },
         });
         reservations.value = res.data;


### PR DESCRIPTION
## Summary
- load reservations for the entire month rather than a single day

## Testing
- `composer install` *(fails: stripe missing in lock)*
- `composer update` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688d57d109f88329b83f6bffc112301d