### PR TITLE
Add reservation source fee rules

### DIFF
--- a/app/Http/Controllers/Api/Shop/ReservationSourceFeeController.php
+++ b/app/Http/Controllers/Api/Shop/ReservationSourceFeeController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers\Api\Shop;
+
+use App\Http\Controllers\Controller;
+use App\Models\ReservationSource;
+use App\Models\ReservationSourceFee;
+use Illuminate\Http\Request;
+
+class ReservationSourceFeeController extends Controller
+{
+    public function index($id)
+    {
+        $shopId = auth('shop')->user()->id;
+        $source = ReservationSource::where('shop_id', $shopId)->findOrFail($id);
+
+        return response()->json($source->fees()->orderBy('min_amount')->get());
+    }
+
+    public function store(Request $request, $id)
+    {
+        $shopId = auth('shop')->user()->id;
+        $source = ReservationSource::where('shop_id', $shopId)->findOrFail($id);
+
+        $data = $request->validate([
+            'fees' => 'required|array|min:1',
+            'fees.*.min_amount' => 'nullable|integer|min:0',
+            'fees.*.max_amount' => 'nullable|integer|min:0',
+            'fees.*.fee_type' => 'required|in:fixed,percent',
+            'fees.*.fee_value' => 'required|integer|min:0',
+        ]);
+
+        $fees = $data['fees'];
+
+        foreach ($fees as $fee) {
+            $min = $fee['min_amount'] ?? 0;
+            $max = $fee['max_amount'];
+            if (!is_null($max) && $min >= $max) {
+                return response()->json(['errors' => ['fees' => ['min_amount must be less than max_amount']]], 422);
+            }
+        }
+
+        usort($fees, function ($a, $b) {
+            return ($a['min_amount'] ?? 0) <=> ($b['min_amount'] ?? 0);
+        });
+
+        $prevMax = null;
+        foreach ($fees as $fee) {
+            $min = $fee['min_amount'] ?? 0;
+            $max = $fee['max_amount'] ?? PHP_INT_MAX;
+            if (!is_null($prevMax) && $min < $prevMax) {
+                return response()->json(['errors' => ['fees' => ['fee ranges overlap']]], 422);
+            }
+            $prevMax = $max;
+        }
+
+        $source->fees()->delete();
+        foreach ($fees as $fee) {
+            $source->fees()->create($fee);
+        }
+
+        return response()->json($source->fees()->orderBy('min_amount')->get());
+    }
+
+    public function destroy(Request $request, $id)
+    {
+        $shopId = auth('shop')->user()->id;
+        $feeId = $request->input('fee_id');
+
+        if (!$feeId) {
+            return response()->json(['errors' => ['fee_id' => ['fee_id is required']]], 422);
+        }
+
+        $fee = ReservationSourceFee::where('id', $feeId)
+            ->whereHas('reservationSource', function ($q) use ($shopId, $id) {
+                $q->where('shop_id', $shopId)->where('id', $id);
+            })
+            ->firstOrFail();
+
+        $fee->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/app/Models/ReservationSource.php
+++ b/app/Models/ReservationSource.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Models\ReservationSourceFee;
 
 // App\Models\ReservationSource
 class ReservationSource extends Model
@@ -14,6 +15,11 @@ class ReservationSource extends Model
     public function reservations()
     {
         return $this->hasMany(Reservation::class);
+    }
+
+    public function fees()
+    {
+        return $this->hasMany(ReservationSourceFee::class);
     }
     public function scopeActive($query)
     {

--- a/app/Models/ReservationSourceFee.php
+++ b/app/Models/ReservationSourceFee.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ReservationSourceFee extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'reservation_source_id',
+        'min_amount',
+        'max_amount',
+        'fee_type',
+        'fee_value',
+    ];
+
+    public function reservationSource()
+    {
+        return $this->belongsTo(ReservationSource::class);
+    }
+
+    /**
+     * Calculate fee based on price and reservation source.
+     */
+    public static function calculate(int $reservationSourceId, int $price): int
+    {
+        $fee = self::where('reservation_source_id', $reservationSourceId)
+            ->where(function ($q) use ($price) {
+                $q->where(function ($query) use ($price) {
+                    $query->whereNull('min_amount')->orWhere('min_amount', '<=', $price);
+                })->where(function ($query) use ($price) {
+                    $query->whereNull('max_amount')->orWhere('max_amount', '>', $price);
+                });
+            })
+            ->orderBy('min_amount')
+            ->first();
+
+        if (!$fee) {
+            return 0;
+        }
+
+        return $fee->fee_type === 'fixed'
+            ? (int) $fee->fee_value
+            : (int) floor($price * $fee->fee_value / 100);
+    }
+}

--- a/database/migrations/2025_08_15_000000_create_reservation_source_fees_table.php
+++ b/database/migrations/2025_08_15_000000_create_reservation_source_fees_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('reservation_source_fees', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('reservation_source_id')->constrained()->onDelete('cascade');
+            $table->integer('min_amount')->nullable();
+            $table->integer('max_amount')->nullable();
+            $table->enum('fee_type', ['fixed', 'percent']);
+            $table->integer('fee_value');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('reservation_source_fees');
+    }
+};

--- a/resources/js/pages/shop/settings/reservation_source/ReservationSourceCreate.vue
+++ b/resources/js/pages/shop/settings/reservation_source/ReservationSourceCreate.vue
@@ -27,6 +27,45 @@
                 </label>
             </div>
 
+            <div class="mb-4">
+                <h3 class="font-semibold mb-2">手数料ルール</h3>
+                <table class="w-full mb-2 text-sm">
+                    <thead>
+                        <tr>
+                            <th class="p-2 border">最小金額</th>
+                            <th class="p-2 border">最大金額</th>
+                            <th class="p-2 border">種別</th>
+                            <th class="p-2 border">手数料</th>
+                            <th class="p-2 border"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-for="(fee, index) in fees" :key="index">
+                            <td class="p-2 border">
+                                <input type="number" v-model.number="fee.min_amount" class="w-full p-1 border rounded" />
+                            </td>
+                            <td class="p-2 border">
+                                <input type="number" v-model.number="fee.max_amount" class="w-full p-1 border rounded" />
+                            </td>
+                            <td class="p-2 border">
+                                <select v-model="fee.fee_type" class="w-full p-1 border rounded">
+                                    <option value="fixed">固定</option>
+                                    <option value="percent">%</option>
+                                </select>
+                            </td>
+                            <td class="p-2 border">
+                                <input type="number" v-model.number="fee.fee_value" class="w-full p-1 border rounded" />
+                            </td>
+                            <td class="p-2 border text-center">
+                                <button type="button" @click="removeFee(index)" class="text-red-500">削除</button>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <button type="button" @click="addFee" class="bg-green-500 text-white px-2 py-1 rounded">手数料ルールを追加</button>
+                <p v-if="feesError" class="text-red-500 text-sm mt-1">{{ feesError }}</p>
+            </div>
+
             <div class="flex justify-between">
                 <button
                     type="submit"
@@ -46,7 +85,7 @@
 </template>
 
 <script setup>
-import { reactive } from "vue";
+import { reactive, ref } from "vue";
 import { useRouter } from "vue-router";
 import axios from "axios";
 import { useShopStore } from "@/stores/shop";
@@ -58,17 +97,36 @@ const form = reactive({
     name: "",
     is_active: true,
 });
+const fees = ref([
+    { min_amount: null, max_amount: null, fee_type: "fixed", fee_value: 0 },
+]);
+const feesError = ref("");
 
 const handleSubmit = async () => {
     try {
-        await axios.post("/api/shop/reservation-sources", {
+        const res = await axios.post("/api/shop/reservation-sources", {
             ...form,
             shop_id: shopStore.shop.id,
         });
+        await axios.post(
+            `/api/shop/reservation-sources/${res.data.id}/fees`,
+            { fees: fees.value }
+        );
         router.push({ name: "shop.settings.reservation_sources" });
     } catch (error) {
+        if (error.response?.status === 422) {
+            feesError.value = error.response.data.errors?.fees?.[0] || "";
+        }
         alert("登録に失敗しました");
         console.error(error);
     }
+};
+
+const addFee = () => {
+    fees.value.push({ min_amount: null, max_amount: null, fee_type: "fixed", fee_value: 0 });
+};
+
+const removeFee = (index) => {
+    fees.value.splice(index, 1);
 };
 </script>

--- a/resources/js/pages/shop/settings/reservation_source/ReservationSourceEdit.vue
+++ b/resources/js/pages/shop/settings/reservation_source/ReservationSourceEdit.vue
@@ -27,6 +27,45 @@
                 </label>
             </div>
 
+            <div class="mb-4">
+                <h3 class="font-semibold mb-2">手数料ルール</h3>
+                <table class="w-full mb-2 text-sm">
+                    <thead>
+                        <tr>
+                            <th class="p-2 border">最小金額</th>
+                            <th class="p-2 border">最大金額</th>
+                            <th class="p-2 border">種別</th>
+                            <th class="p-2 border">手数料</th>
+                            <th class="p-2 border"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-for="(fee, index) in fees" :key="index">
+                            <td class="p-2 border">
+                                <input type="number" v-model.number="fee.min_amount" class="w-full p-1 border rounded" />
+                            </td>
+                            <td class="p-2 border">
+                                <input type="number" v-model.number="fee.max_amount" class="w-full p-1 border rounded" />
+                            </td>
+                            <td class="p-2 border">
+                                <select v-model="fee.fee_type" class="w-full p-1 border rounded">
+                                    <option value="fixed">固定</option>
+                                    <option value="percent">%</option>
+                                </select>
+                            </td>
+                            <td class="p-2 border">
+                                <input type="number" v-model.number="fee.fee_value" class="w-full p-1 border rounded" />
+                            </td>
+                            <td class="p-2 border text-center">
+                                <button type="button" @click="removeFee(index)" class="text-red-500">削除</button>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <button type="button" @click="addFee" class="bg-green-500 text-white px-2 py-1 rounded">手数料ルールを追加</button>
+                <p v-if="feesError" class="text-red-500 text-sm mt-1">{{ feesError }}</p>
+            </div>
+
             <div class="flex space-x-4">
                 <button
                     type="submit"
@@ -57,6 +96,8 @@ const form = ref({
     is_active: true,
 });
 const errors = ref({});
+const fees = ref([{ min_amount: null, max_amount: null, fee_type: "fixed", fee_value: 0 }]);
+const feesError = ref("");
 
 const load = async () => {
     try {
@@ -67,7 +108,12 @@ const load = async () => {
             name: res.data.name,
             is_active: Boolean(res.data.is_active),
         };
-        console.log(form.value.is_active);
+        const feeRes = await axios.get(
+            `/api/shop/reservation-sources/${route.params.id}/fees`
+        );
+        fees.value = feeRes.data.length
+            ? feeRes.data
+            : [{ min_amount: null, max_amount: null, fee_type: "fixed", fee_value: 0 }];
     } catch (e) {
         console.error(e);
         alert("取得に失敗しました");
@@ -80,15 +126,28 @@ const submit = async () => {
             `/api/shop/reservation-sources/${route.params.id}`,
             form.value
         );
+        await axios.post(
+            `/api/shop/reservation-sources/${route.params.id}/fees`,
+            { fees: fees.value }
+        );
         router.push("/shop/settings/reservation-sources");
     } catch (e) {
         if (e.response?.status === 422) {
-            errors.value = e.response.data.errors;
+            errors.value = e.response.data.errors || {};
+            feesError.value = e.response.data.errors?.fees?.[0] || "";
         } else {
             console.error(e);
             alert("更新に失敗しました");
         }
     }
+};
+
+const addFee = () => {
+    fees.value.push({ min_amount: null, max_amount: null, fee_type: "fixed", fee_value: 0 });
+};
+
+const removeFee = (index) => {
+    fees.value.splice(index, 1);
 };
 
 onMounted(load);

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Api\Shop\StaffController;
 use App\Http\Controllers\Api\Shop\MenuCategoryController;
 use App\Http\Controllers\Api\Shop\SaleController;
 use App\Http\Controllers\Api\Shop\ReservationSourceController;
+use App\Http\Controllers\Api\Shop\ReservationSourceFeeController;
 use App\Http\Controllers\Api\UserController;
 use App\Http\Controllers\Api\StripeController;
 use App\Http\Controllers\Api\Staff\AuthController as StaffAuthController;
@@ -72,6 +73,9 @@ Route::prefix('shop')->group(function () {
         Route::get('/reservation-sources/{id}', [ReservationSourceController::class, 'show']);
         Route::put('/reservation-sources/{id}', [ReservationSourceController::class, 'update']);
         Route::delete('/reservation-sources/{id}', [ReservationSourceController::class, 'destroy']);
+        Route::get('/reservation-sources/{id}/fees', [ReservationSourceFeeController::class, 'index']);
+        Route::post('/reservation-sources/{id}/fees', [ReservationSourceFeeController::class, 'store']);
+        Route::delete('/reservation-sources/{id}/fees', [ReservationSourceFeeController::class, 'destroy']);
         // 予約の取得・登録など（/api/shop/reservations）
         Route::get('reservations', [ReservationController::class, 'index']);
         Route::post('reservations', [ReservationController::class, 'store']);


### PR DESCRIPTION
## Summary
- add reservation_source_fees table and model with fee calculation helper
- expose CRUD API for reservation source fees with validation
- allow managing fee rules in reservation source create/edit pages

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: Required package "stripe/stripe-php" is not present in the lock file)*
- `composer update` *(fails: curl error 56 while downloading packages.json)*
- `npm run build` *(fails: Could not resolve "../customer/CustomerCreateModal.vue" from EditReservationModal.vue)*

------
https://chatgpt.com/codex/tasks/task_e_688d8bf015408329afcdf4e2527860de