### PR TITLE
Fix month view to load reservations

### DIFF
--- a/resources/js/pages/shop/Reservation/MonthView.vue
+++ b/resources/js/pages/shop/Reservation/MonthView.vue
@@ -70,7 +70,7 @@
 </template>
 
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, ref, onMounted, watch } from 'vue'
 import dayjs from 'dayjs'
 
 const props = defineProps({
@@ -89,6 +89,17 @@ const emit = defineEmits([
 const selectedDate = ref(dayjs().format('YYYY-MM-DD'))
 
 const month = ref(dayjs(`${props.currentMonth}-01`))
+
+watch(
+    () => props.currentMonth,
+    (val) => {
+        month.value = dayjs(`${val}-01`)
+    }
+)
+
+onMounted(() => {
+    emit('update:currentMonth', month.value.format('YYYY-MM'))
+})
 
 const reservationsMap = computed(() => {
     const map = {}


### PR DESCRIPTION
## Summary
- update MonthView to sync when mounted
- ensure month view loads reservations for current month automatically

## Testing
- `php artisan test` *(fails: vendor folder missing)*
- `npm run build` *(fails: build errors due to missing file)*

------
https://chatgpt.com/codex/tasks/task_e_688d5c8fa0f88329914c9764809526d8